### PR TITLE
Don't use power save setup mode on blank devices

### DIFF
--- a/Shoe/Shoe.ino
+++ b/Shoe/Shoe.ino
@@ -65,8 +65,12 @@ void setup()
         delay(5);
         InterpretCommand();
 
-        delay(600); // TODO may want to loop InterpretCommand during this
-        Simblee_ULPDelay(MILLISECONDS(800));
+        // Don't try to sleep if the deviceID isn't set
+        // (going to sleep may mess up the serial console; fresh devices need console access to set the ID)
+        if (romManager.config.deviceID != 0x00) {
+            delay(600); // TODO may want to loop InterpretCommand during this
+            Simblee_ULPDelay(MILLISECONDS(800));
+        }
     }
     stopBroadcast();
     d("Time set.");


### PR DESCRIPTION
This keeps the serial terminal responsive when setting up the ID on blank sensors. This also avoids any potential issues with sleep mode and serial.